### PR TITLE
fixed icon directory

### DIFF
--- a/assets/stylesheets/font-awesome.css
+++ b/assets/stylesheets/font-awesome.css
@@ -6,8 +6,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('/w/skins/foreground/assets/fonts/fontawesome-webfont.eot?v=4.0.3');
-  src: url('/w/skins/foreground/assets/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), url('/w/skins/foreground/assets/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), url('/w/skins/foreground/assets/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype'), url('/w/skins/foreground/assets/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg');
+  src: url('../fonts/fontawesome-webfont.eot?v=4.0.3');
+  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Some mediawiki installations don't use /w/ as the root, so the font awesome icons don't show up. This would fix that and let people use any installation method, as long as the stylesheet and font directories stay siblings. 
