### PR TITLE
[Feature][#139] Add an image or icon to the navbar

### DIFF
--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -19,6 +19,7 @@ class Skinforeground extends SkinTemplate {
 			'NavWrapperType' => 'divonly',
 			'showHelpUnderTools' => true,
 			'showRecentChangesUnderTools' => true,
+			'wikiName' => &$GLOBALS['wgSitename'],
 			'IeEdgeCode' => 1
 		);
 		foreach ($wgForegroundFeaturesDefaults as $fgOption => $fgOptionValue) {
@@ -68,72 +69,81 @@ class foregroundTemplate extends BaseTemplate {
 ?>
 <!-- START FOREGROUNDTEMPLATE -->
 		<nav class="top-bar">
-						<ul class="title-area">
-							<li class="name"><h1><a href="<?php echo $this->data['nav_urls']['mainpage']['href']; ?>"><?php echo $this->text('sitename'); ?></a></h1></li>
-						   <li class="toggle-topbar menu-icon"><a href="#"><span><?php echo wfMessage( 'foreground-menutitle' )->text(); ?></span></a></li>
-						</ul>
+			<ul class="title-area">
+				<li class="name">
+					<h1 class="title-name">
+					<a href="<?php echo $this->data['nav_urls']['mainpage']['href']; ?>">
+					<img alt="<?php echo $this->text('sitename'); ?>" src="<?php echo $this->text('logopath') ?>" style="max-width: 64px;height:auto; max-height:36px; display: inline-block; vertical-align:middle;">
+					<div class="title-name" style="display: inline-block;"><?php echo $wgForegroundFeatures['wikiName']; ?></div>
+					</a>
+					</h1>
+				</li>
+				<li class="toggle-topbar menu-icon">
+					<a href="#"><span><?php echo wfMessage( 'foreground-menutitle' )->text(); ?></span></a>
+				</li>
+			</ul>
 
-						<section class="top-bar-section">
+		<section class="top-bar-section">
 
-		    		<ul id="top-bar-left" class="left">
-		 						<li class="divider"></li>
-									<?php foreach ( $this->getSidebar() as $boxName => $box ) { if ( ($box['header'] != wfMessage( 'toolbox' )->text())  ) { ?>
-									<li class="has-dropdown active"  id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
-											<a href="#"><?php echo htmlspecialchars( $box['header'] ); ?></a>
-											<?php if ( is_array( $box['content'] ) ) { ?>
-												<ul class="dropdown">
-													<?php foreach ( $box['content'] as $key => $item ) { echo $this->makeListItem( $key, $item ); } ?>
-        								</ul>
-											<?php } } ?>
-									<?php } ?>
-		    		</ul>
+			<ul id="top-bar-left" class="left">
+				<li class="divider"></li>
+					<?php foreach ( $this->getSidebar() as $boxName => $box ) { if ( ($box['header'] != wfMessage( 'toolbox' )->text())  ) { ?>
+				<li class="has-dropdown active"  id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
+					<a href="#"><?php echo htmlspecialchars( $box['header'] ); ?></a>
+						<?php if ( is_array( $box['content'] ) ) { ?>
+							<ul class="dropdown">
+								<?php foreach ( $box['content'] as $key => $item ) { echo $this->makeListItem( $key, $item ); } ?>
+							</ul>
+								<?php } } ?>
+						<?php } ?>
+			</ul>
 
-		        <ul id="top-bar-right" class="right">
-			      <li class="has-form">
-		        	<form action="<?php $this->text( 'wgScript' ); ?>" id="searchform" class="mw-search">
-		        		<div class="row collapse">
-		            	<div class="small-8 columns">
-		        				<?php echo $this->makeSearchInput(array('placeholder' => wfMessage('searchsuggest-search')->text(), 'id' => 'searchInput') ); ?>
-		        			</div>
-		        			 <div class="small-4 columns">
-		        				<button type="submit" class="button search"><?php echo wfMessage( 'search' )->text() ?></button>
-		        			</div>
-		        		</div>
-		        	</form>
-		        </li>
-		         <li class="divider show-for-small"></li>
-		         <li class="has-form">
+			<ul id="top-bar-right" class="right">
+				<li class="has-form">
+					<form action="<?php $this->text( 'wgScript' ); ?>" id="searchform" class="mw-search">
+						<div class="row collapse">
+						<div class="small-8 columns">
+							<?php echo $this->makeSearchInput(array('placeholder' => wfMessage('searchsuggest-search')->text(), 'id' => 'searchInput') ); ?>
+						</div>
+						<div class="small-4 columns">
+							<button type="submit" class="button search"><?php echo wfMessage( 'search' )->text() ?></button>
+						</div>
+						</div>
+						</form>
+				</li>
+				<li class="divider show-for-small"></li>
+				<li class="has-form">
 
-								<li class="has-dropdown active"><a href="#"><i class="fa fa-cogs"></i></a>
-									<ul id="toolbox-dropdown" class="dropdown">
-										<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
-										<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-										<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/wiki/Help:Contents"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
-									</ul>
-								</li>
+				<li class="has-dropdown active"><a href="#"><i class="fa fa-cogs"></i></a>
+					<ul id="toolbox-dropdown" class="dropdown">
+						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
+						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/wiki/Help:Contents"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+					</ul>
+				</li>
 
-							<?php if ($wgUser->isLoggedIn()): ?>
-								<li id="personal-tools-dropdown" class="has-dropdown active"><a href="#"><i class="fa fa-user"></i></a>
-									<ul class="dropdown">
-									<?php foreach ( $this->getPersonalTools() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
-									</ul>
-								</li>
+				<?php if ($wgUser->isLoggedIn()): ?>
+				<li id="personal-tools-dropdown" class="has-dropdown active"><a href="#"><i class="fa fa-user"></i></a>
+					<ul class="dropdown">
+						<?php foreach ( $this->getPersonalTools() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
+					</ul>
+				</li>
 
-							<?php else: ?>
+						<?php else: ?>
 							<li>
 								<?php if (isset($this->data['personal_urls']['anonlogin'])): ?>
-									<a href="<?php echo $this->data['personal_urls']['anonlogin']['href']; ?>"><?php echo wfMessage( 'login' )->text() ?></a>
+								<a href="<?php echo $this->data['personal_urls']['anonlogin']['href']; ?>"><?php echo wfMessage( 'login' )->text() ?></a>
 								<?php elseif (isset($this->data['personal_urls']['login'])): ?>
 									<a href="<?php echo htmlspecialchars($this->data['personal_urls']['login']['href']); ?>"><?php echo wfMessage( 'login' )->text() ?></a>
-								<?php else: ?>
-									<?php echo Linker::link(Title::newFromText('Special:UserLogin'), wfMessage( 'login' )->text()); ?>
-								<?php endif; ?>
+									<?php else: ?>
+										<?php echo Linker::link(Title::newFromText('Special:UserLogin'), wfMessage( 'login' )->text()); ?>
+									<?php endif; ?>
 							</li>
 
-							<?php endif; ?>
+				<?php endif; ?>
 
-		       </ul>
-		     </section>
+			</ul>
+		</section>
 		</nav>
 		<?php if ($wgForegroundFeatures['NavWrapperType'] != '0') echo "</div>"; ?>
 		


### PR DESCRIPTION
Adding a navbar icon, option to change displayed name in navbar from $wgSitename, and cleaning up formatting of code.
### Information about this PR

This PR enables an icon image to be displayed in the title bar using $wgLogo, left of the wiki's set site name(`$wgSitename`).  See Feature #139.
- The image will downsize to an attempted 16:9 setting if larger than 64px wide x 36px height but maintain aspect ratio of image. 
- Set your image with the standard `$wgLogo` in `LocalSettings.php`
- Option to shorten displayed `$wgSitename`

To shorten the sitename, add `'wikiName' =>'Site Title To Show'` to the `$wgForegroundFeatures = array(` setting the Site Title To Show to your preferred title.

If you are not using the `$wgForegroundFeatures = array(` then add the below

```
require_once "$IP/skins/foreground/foreground.php";
```
### Example

```
require_once "$IP/skins/foreground/foreground.php";
$wgForegroundFeatures = array(
            'wikiName' =>'Site Title To Show'
);
```
### Adjusting Width of Title Area

This is the common setting of the title area.

```
.top-bar .name h1 a {
padding: 0 15px;
}
```

You can gain more horizontal space with an addition of CSS in `MediaWiki:Common.css` or `MediaWiki:Foreground.css`. Example, gain 20px more of horizontal space.

```
.top-bar .name h1 a {
padding: 0 5px;
}
```

You can also hide the title or the image based on screen size with additional CSS.
