### PR TITLE
Better options for footer, icons display, social follow

### DIFF
--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -214,13 +214,15 @@ class foregroundTemplate extends BaseTemplate {
 
 			<footer class="row">
 				<div id="footer">
-					<div class="social-footer large-12 small-12 columns">
-					<?php if ($wgForegroundFeatures['addThisFollowPUBID'] != '') { ?>		
-						<!-- Go to www.addthis.com/dashboard to customize your tools -->
-						<div class="addthis_horizontal_follow_toolbox"></div>
-						<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=<?php echo $wgForegroundFeatures['addThisFollowPUBID'];?>"></script>
+					<?php if ($wgForegroundFeatures['addThisFollowPUBID'] != '') { ?>
+						<div class="social-footer large-12 small-12 columns">
+							<div class="social-links">
+							<!-- Go to www.addthis.com/dashboard to customize your tools -->
+							<div class="addthis_horizontal_follow_toolbox"></div>
+							<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=<?php echo $wgForegroundFeatures['addThisFollowPUBID'];?>"></script>
+							</div>
+						</div>
 					<?php } ?>
-					</div>
 					<div id="footer-left" class="<?php echo $footerLeftClass;?>">
 					<ul id="footer-left">
 						<?php foreach ( $this->getFooterLinks( "flat" ) as $key ) { ?>

--- a/assets/stylesheets/foreground.css
+++ b/assets/stylesheets/foreground.css
@@ -162,14 +162,29 @@ margin: 0;
 list-style-type: none;
 }
 
-.social-footer p {
-display: none;
-}
-
+/* Make social footer center need overflow:hidden and other div classes */
 .social-footer {
 margin: 0 0 1em;
 font-size: 90%;
+overflow: hidden;
 }
+/* Hide all text in p elements */
+.social-footer p {
+display: none;
+}
+/* Outer wrap */
+.social-links {
+position: relative;
+left: 50%;
+float: left;
+}
+/* addThis container (inner wrap) */
+.addthis_horizontal_follow_toolbox {
+position: relative;
+left: -50%;
+float: left;
+}
+/* end social footer classes */
 
 #footer-left {
 font-size: 90%;


### PR DESCRIPTION
This PR addresses #144 and #113. Adds two new `$wgForegroundFeatures` choices.

```
            'showFooterIcons' => 0,
            'addThisFollowPUBID' => ''
```

If you enable `showFooterIcons` to `true` or `1`, then the icons for the footer will be shown instead of text. Also changes to more of the default MW layout flow when on larger displays.

If you set `addThisFollowPUBID` to your addThis publisher follow id account# and you are using the free version of horizontal follow buttons. The follow buttons will display in the footer. 

Added CSS to control the footer layout better.
