### PR TITLE
Fix for h3 larger than h2 in small screen issue #69

### DIFF
--- a/assets/stylesheets/foreground.css
+++ b/assets/stylesheets/foreground.css
@@ -285,18 +285,6 @@ h1,h2,h3,h4,h5,h6 {
   font-size: 0.4em;
 }
 
-h3 {
-  font-weight: normal;
-  font-size:1em;
-}
-
-.ns-subject h3,
-.ns-special h3,
-.page-Main_Page h3 {
-  font-weight: bold;
-  font-size: 2em;
-}
-
 p.title {
   padding: 0.9375em;
 }


### PR DESCRIPTION
Not sure why these changes for H3 heading elements were placed in ```foreground.css``` but it should fix issue #69 