### PR TITLE
Support MediaWiki 1.26

### DIFF
--- a/foreground.php
+++ b/foreground.php
@@ -23,7 +23,7 @@ $wgExtensionCredits['skin'][] = array(
 		'Jamie Thingelstad',
 		'Tom Hutchison',
 		'...'
-		),
+	),
 	'descriptionmsg' => 'foreground-desc'
 );
 
@@ -35,7 +35,8 @@ $wgMessagesDirs['SkinForeground'] = __DIR__ . '/i18n';
 $wgExtensionMessagesFiles['SkinForeground'] = __DIR__ . '/Foreground.i18n.php';
 
 $wgResourceModules['skins.foreground'] = array(
-	'styles'         => array(
+    'position' => 'top',
+    'styles'         => array(
     	'foreground/assets/stylesheets/normalize.css',
         'foreground/assets/stylesheets/font-awesome.css',
     	'foreground/assets/stylesheets/foundation.css',


### PR DESCRIPTION
Mediawiki 1.26 now requires     'position' => 'top', to be set in resourceloader. it wont break any compat but mediawiki 1.26 will not work well with this skin if not set it will show error warrnings.