### PR TITLE
Explicitly set $wgResourceModules['skins.foreground']['position'] = 'bottom'

### DIFF
--- a/foreground.php
+++ b/foreground.php
@@ -36,29 +36,30 @@ $wgExtensionMessagesFiles['SkinForeground'] = __DIR__ . '/Foreground.i18n.php';
 
 $wgResourceModules['skins.foreground'] = array(
 	'styles'         => array(
-    	'foreground/assets/stylesheets/normalize.css',
-        'foreground/assets/stylesheets/font-awesome.css',
-    	'foreground/assets/stylesheets/foundation.css',
-    	'foreground/assets/stylesheets/foreground.css',
-        'foreground/assets/stylesheets/foreground-print.css',
-    	'foreground/assets/stylesheets/jquery.autocomplete.css',
-    	'foreground/assets/stylesheets/responsive-tables.css'
-    ),
-    'scripts'        => array(
-        'foreground/assets/scripts/vendor/custom.modernizr.js',
-        'foreground/assets/scripts/vendor/fastclick.js',
-        'foreground/assets/scripts/vendor/responsive-tables.js',
-        'foreground/assets/scripts/foundation/foundation.js',
-        'foreground/assets/scripts/foundation/foundation.topbar.js',
-        'foreground/assets/scripts/foundation/foundation.dropdown.js',
-        'foreground/assets/scripts/foundation/foundation.section.js',
-        'foreground/assets/scripts/foundation/foundation.clearing.js',
-        'foreground/assets/scripts/foundation/foundation.cookie.js',
-        'foreground/assets/scripts/foundation/foundation.placeholder.js',
-        'foreground/assets/scripts/foundation/foundation.forms.js',
-        'foreground/assets/scripts/foundation/foundation.alerts.js',
-        'foreground/assets/scripts/foreground.js'
-    ),
-    'remoteBasePath' => &$GLOBALS['wgStylePath'],
-    'localBasePath'  => &$GLOBALS['wgStyleDirectory']
+		'foreground/assets/stylesheets/normalize.css',
+		'foreground/assets/stylesheets/font-awesome.css',
+		'foreground/assets/stylesheets/foundation.css',
+		'foreground/assets/stylesheets/foreground.css',
+		'foreground/assets/stylesheets/foreground-print.css',
+		'foreground/assets/stylesheets/jquery.autocomplete.css',
+		'foreground/assets/stylesheets/responsive-tables.css'
+	),
+	'scripts'        => array(
+		'foreground/assets/scripts/vendor/custom.modernizr.js',
+		'foreground/assets/scripts/vendor/fastclick.js',
+		'foreground/assets/scripts/vendor/responsive-tables.js',
+		'foreground/assets/scripts/foundation/foundation.js',
+		'foreground/assets/scripts/foundation/foundation.topbar.js',
+		'foreground/assets/scripts/foundation/foundation.dropdown.js',
+		'foreground/assets/scripts/foundation/foundation.section.js',
+		'foreground/assets/scripts/foundation/foundation.clearing.js',
+		'foreground/assets/scripts/foundation/foundation.cookie.js',
+		'foreground/assets/scripts/foundation/foundation.placeholder.js',
+		'foreground/assets/scripts/foundation/foundation.forms.js',
+		'foreground/assets/scripts/foundation/foundation.alerts.js',
+		'foreground/assets/scripts/foreground.js'
+	),
+	'remoteBasePath' => &$GLOBALS['wgStylePath'],
+	'localBasePath'  => &$GLOBALS['wgStyleDirectory'],
+	'position'       => 'bottom'
 );


### PR DESCRIPTION


Without this you get warnings like

    OutputPage::getModuleStyles: style module should define its position explicitly: skins.foreground ResourceLoaderFileModule

on every page load.

Note that 'top' could be used instead and that might help keep the skin from flashing.

Also w/s cleanup per MW coding standards.