### PR TITLE
Fix mw 1.26 compatibility

### DIFF
--- a/foreground.php
+++ b/foreground.php
@@ -35,6 +35,7 @@ $wgMessagesDirs['SkinForeground'] = __DIR__ . '/i18n';
 $wgExtensionMessagesFiles['SkinForeground'] = __DIR__ . '/Foreground.i18n.php';
 
 $wgResourceModules['skins.foreground'] = array(
+	'position'       => 'top',
 	'styles'         => array(
 		'foreground/assets/stylesheets/normalize.css',
 		'foreground/assets/stylesheets/font-awesome.css',
@@ -61,5 +62,4 @@ $wgResourceModules['skins.foreground'] = array(
 	),
 	'remoteBasePath' => &$GLOBALS['wgStylePath'],
 	'localBasePath'  => &$GLOBALS['wgStyleDirectory'],
-	'position'       => 'bottom'
 );


### PR DESCRIPTION
Change position to top since it includes styles and JavaScript and since JavaScript indent seperatly we need to set it to top.

Haven't tested but looking at vector this is how it sets it.