### PR TITLE
Update some mobile specific css

### DIFF
--- a/assets/stylesheets/foreground.css
+++ b/assets/stylesheets/foreground.css
@@ -818,3 +818,10 @@ body.mw-special-Userlogin h2.title {
 #pt-uls a.uls-trigger {
   padding-left:15px !important;
 }
+
+@media only screen and (min-width: 550px) {
+#p-cactions {
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+}
+}


### PR DESCRIPTION
Lets use overflow so that the pages can easily be touched to scroll left or right.

Some pages have more text making the screen go out.

Sometimes the content will overlap this fixes it by adding an overflow css meaning that to view the rest of the content you are to scroll on an mobile device.

@Hutchy68 could you review this.