### PR TITLE
Fix #194

### DIFF
--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -136,7 +136,7 @@ class foregroundTemplate extends BaseTemplate {
 					<ul id="toolbox-dropdown" class="dropdown">
 						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
 						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'foreground-helplink', 'foreground-contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'foreground-helplink' )->inContentLanguage()->text(), wfMessage( 'foreground-contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
 					</ul>
 				</li>
 

--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -136,7 +136,7 @@ class foregroundTemplate extends BaseTemplate {
 					<ul id="toolbox-dropdown" class="dropdown">
 						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
 						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/wiki/Help:Contents"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo wfMessage( 'help' )->text() ?>:<?php echo wfMessage( 'toc' )->text() ?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
 					</ul>
 				</li>
 

--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -136,7 +136,7 @@ class foregroundTemplate extends BaseTemplate {
 					<ul id="toolbox-dropdown" class="dropdown">
 						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
 						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'foreground-helplink' )->inContentLanguage()->text(), wfMessage( 'foreground-contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'foreground-helplink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
 					</ul>
 				</li>
 

--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -136,7 +136,7 @@ class foregroundTemplate extends BaseTemplate {
 					<ul id="toolbox-dropdown" class="dropdown">
 						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
 						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'helplink', 'contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'foreground-helplink', 'foreground-contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
 					</ul>
 				</li>
 

--- a/Foreground.skin.php
+++ b/Foreground.skin.php
@@ -136,7 +136,7 @@ class foregroundTemplate extends BaseTemplate {
 					<ul id="toolbox-dropdown" class="dropdown">
 						<?php foreach ( $this->getToolbox() as $key => $item ) { echo $this->makeListItem($key, $item); } ?>
 						<?php if ($wgForegroundFeatures['showRecentChangesUnderTools']): ?><li id="n-recentchanges"><?php echo Linker::specialLink('Recentchanges') ?></li><?php endif; ?>
-						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo wfMessage( 'help' )->text() ?>:<?php echo wfMessage( 'toc' )->text() ?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
+						<?php if ($wgForegroundFeatures['showHelpUnderTools']): ?><li id="n-help" <?php echo Linker::tooltip('help') ?>><a href="/index.php/<?php echo Skin::makeInternalOrExternalUrl( wfMessage( 'helplink', 'contentlink' )->inContentLanguage()->text() )?>"><?php echo wfMessage( 'help' )->text() ?></a></li><?php endif; ?>
 					</ul>
 				</li>
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,5 +7,7 @@
 	"skinname-foreground": "Foreground",
 	"foreground-desc": "Provides a skin that focuses on putting your content in the foreground",
 	"foreground-browsermsg": "may not look as expected in this version of Internet Explorer. We recommend you upgrade to a newer version of Internet Explorer or switch to a browser like Firefox or Chrome.",
-	"foreground-menutitle": "Menu"
+	"foreground-menutitle": "Menu",
+	"foreground-helplink": "Help:",
+	"foreground-contentlink": "Contents",
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,5 +9,5 @@
 	"foreground-browsermsg": "may not look as expected in this version of Internet Explorer. We recommend you upgrade to a newer version of Internet Explorer or switch to a browser like Firefox or Chrome.",
 	"foreground-menutitle": "Menu",
 	"foreground-helplink": "Help:",
-	"foreground-contentlink": "Contents",
+	"foreground-contentlink": "Contents"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,6 +8,5 @@
 	"foreground-desc": "Provides a skin that focuses on putting your content in the foreground",
 	"foreground-browsermsg": "may not look as expected in this version of Internet Explorer. We recommend you upgrade to a newer version of Internet Explorer or switch to a browser like Firefox or Chrome.",
 	"foreground-menutitle": "Menu",
-	"foreground-helplink": "Help:",
-	"foreground-contentlink": "Contents"
+	"foreground-helplink": "Help:Contents"
 }


### PR DESCRIPTION
Do not hard set the help link.

Replace /wiki/ with /index.php/ if a user sets the path to wiki or something else then index.php will automatically redirects to that link.

Also allow help and contents to be displayed in the current wikis language.