### PR TITLE
Add styles for Special:Preferences

### DIFF
--- a/assets/stylesheets/mediawiki.special.preferences.styles.less
+++ b/assets/stylesheets/mediawiki.special.preferences.styles.less
@@ -1,0 +1,86 @@
+
+		&:first-child {
+			margin-left: 1px;
+		}
+
+		&.selected {
+			a {
+				background-color: #fafafa;
+				border-style: solid;
+				border-width: 1px;
+				border-image: linear-gradient(to top, #ccc, rgba(0, 0, 0, 0)) 1 100%;
+				margin: -1px;
+				background-position: bottom;
+				background-repeat: repeat-x;
+				color: #333;
+			}
+		}
+	}
+
+	a,
+	a:active {
+		display: inline-block;
+		position: relative;
+		color: #0645ad;
+		padding: 0.5em;
+		text-decoration: none;
+		background-image: none;
+		font-size: 0.9em;
+	}
+
+	a:hover,
+	a:focus {
+		text-decoration: underline;
+	}
+}
+
+.client-js #preferences {
+	float: left;
+	width: 100%;
+	margin: 0;
+	clear: both;
+	border: solid 1px #ccc;
+	background-color: #fafafa;
+
+	fieldset {
+		border: none;
+		border-top: solid 1px #ccc;
+	}
+
+	>fieldset {
+		border: none;
+		padding: 0;
+		margin: 1em;
+
+		>legend {
+			display: none;
+		}
+	}
+
+	legend {
+		color: #666;
+	}
+
+	td {
+		padding-left: 0.5em;
+		padding-right: 0.5em;
+	}
+
+	div.mw-prefs-buttons {
+		padding: 1em;
+
+		input {
+			margin-right: 0.25em;
+		}
+	}
+}
+
+.htmlform-tip {
+	font-size: x-small;
+	padding: .2em 2em;
+	color: #666;
+}
+
+fieldset legend {
+	background: none !important;
+}

--- a/assets/stylesheets/mediawiki.special.preferences.styles.less
+++ b/assets/stylesheets/mediawiki.special.preferences.styles.less
@@ -1,4 +1,35 @@
+@import "mediawiki.mixins";
 
+/**
+ * The following code is highly modified from monobook. It would be nice if the
+ * preftoc id was more human readable like preferences-toc for instance,
+ * howerver this would require backporting the other skins.
+ */
+
+.client-js #preftoc {
+	/* Tabs */
+	width: 100%;
+	float: left;
+	clear: both;
+	margin: 0;
+	padding: 0;
+	background-position: bottom left;
+	background-repeat: no-repeat;
+
+	li {
+		/* Tab */
+		float: left;
+		margin: 0;
+		padding: 0;
+		padding-right: 1px;
+		height: 2.25em;
+		white-space: nowrap;
+		list-style-type: none;
+		list-style-image: none;
+		background-position: bottom right;
+		background-repeat: no-repeat;
+
+		/* Sadly, IE6 won't understand this */
 		&:first-child {
 			margin-left: 1px;
 		}

--- a/foreground.php
+++ b/foreground.php
@@ -78,3 +78,11 @@ $wgResourceModules['skins.foreground.js'] = array(
 	'remoteBasePath' => &$GLOBALS['wgStylePath'],
 	'localBasePath'  => &$GLOBALS['wgStyleDirectory']
 );
+
+$wgResourceModuleSkinStyles['foreground'] = array(
+	'+mediawiki.special.preferences.styles' => array(
+		'assets/stylesheets/mediawiki.special.preferences.styles.less'
+	),
+	'remoteBasePath' => &$GLOBALS['wgStylePath'],
+	'localBasePath'  => &$GLOBALS['wgStyleDirectory']
+);

--- a/skin.json
+++ b/skin.json
@@ -58,6 +58,11 @@
 		"localBasePath": "",
 		"remoteSkinPath": "foreground"
 	},
+	"ResourceModuleSkinStyles": {
+		"foreground": {
+			"+mediawiki.special.preferences.styles": "assets/stylesheets/mediawiki.special.preferences.styles.less"
+		}
+	},
 	"config": {},
 	"manifest_version": 1
 }


### PR DESCRIPTION
This adds some styles to Special:Preferences to clear some things up. Like instead of the sections being shown from top to bottom they are shown from left to right now. They also have some colour for each tab as long as you click on the tab.