### PR TITLE
Make LICENSE for project visible

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,16 @@
-Copyright (c) 2013, Garrick Van Buren, Jamie Thingelstad All rights
-reserved.
+Copyright (c) 2013, Garrick Van Buren, Jamie Thingelstad, Tom Hutchison.
+All rights reserved.
+
+The license text below "====" applies to all files within this
+distribution, other than those that are in a directory which contains
+files named "LICENSE" or "COPYING", or a subdirectory thereof. For
+those files, the license text contained in said file overrides any
+license information contained in directories of smaller depth.
+Alternative licenses are typically used for software that is provided
+by external parties, and merely packaged with the Foreground release
+for convenience.
+
+====
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/foreground.php
+++ b/foreground.php
@@ -6,7 +6,7 @@
  * @file
  * @ingroup Skins
  * @author Garrick Van Buren, Jamie Thingelstad, Tom Hutchison
- * @license 2-clause BSD
+ * @license BSD-2-Clause
  */
 
 if ( function_exists( 'wfLoadSkin' ) ) {
@@ -21,17 +21,18 @@ if ( function_exists( 'wfLoadSkin' ) ) {
 }
 
 $wgExtensionCredits['skin'][] = array(
-	'path'		 => __FILE__,
-	'name'		 => 'Foreground',
-	'url'		 => 'http://foreground.thingelstad.com/',
-	'author'	 => array(
+	'path' => __FILE__,
+	'name' => 'Foreground',
+	'url' => 'https://github.com/thingles/foreground',
+	'author' => array(
 		'Garrick Van Buren',
 		'Jamie Thingelstad',
 		'Tom Hutchison',
 		'...'
 	),
-	'version' => '2.0.0 (Albert)',
-	'descriptionmsg' => 'foreground-desc'
+	'version' => '2.0.1-alpha',
+	'descriptionmsg' => 'foreground-desc',
+	'license-name' => 'BSD-2-Clause'
 );
 
 $wgValidSkinNames['foreground'] = 'Foreground';

--- a/skin.json
+++ b/skin.json
@@ -1,14 +1,15 @@
 {
 	"name": "Foreground",
-	"version": "2.0.0 (Albert)",
+	"version": "2.0.1-alpha",
 	"author": [
 		"Garrick Van Buren",
 		"Jamie Thingelstad",
 		"Tom Hutchison",
 		"..."
 	],
-	"url": "http://foreground.thingelstad.com",
+	"url": "https://github.com/thingles/foreground",
 	"descriptionmsg": "foreground-desc",
+	"license-name": "BSD-2-Clause",
 	"type": "skin",
 	"ValidSkinNames": {
 		"foreground": "Foreground"


### PR DESCRIPTION
* Provide license label on special page "Version"
* Add information about packaged software
* Update link to point to the repo
* Bump to development version

Refs: https://github.com/thingles/foreground/issues/185