### PR TITLE
Ve icon fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Version 2.1
 
+* [code] Moved icon appending for Visual Editor to `(window).load` function
+* [code] Improved styling of TOC
 * [code] [b/c break] Switch to MW 1.25+ extension registration mechanism
 * [code] [b/c break] Removed I18n shim for < MW 1.23
 * [code] Move Echo above Page Actions button

--- a/assets/scripts/foreground.js
+++ b/assets/scripts/foreground.js
@@ -18,9 +18,6 @@ jQuery(document).ready(function() {
   // Append font-awesome icons
   jQuery('[id^=ca-nstab] a').prepend('<div class="drop-icon"><i class="fa fa-file fa-fw"></i></div>')
   jQuery('li#ca-talk a').prepend('<div class="drop-icon"><i class="fa fa-comments-o fa-fw"></i></div>')
-  jQuery('li#ca-edit a').prepend('<div class="drop-icon"><i class="fa fa-pencil-square-o fa-fw"></i></div>')
-  jQuery('li#ca-ve-edit a').prepend('<div class="drop-icon"><i class="fa fa-pencil fa-fw"></i></div>')
-  jQuery('li#ca-viewsource a').prepend('<div class="drop-icon"><i class="fa fa-book fa-fw"></i></div>')
   jQuery('li#ca-form_edit a').prepend('<div class="drop-icon"><i class="fa fa-pencil-square fa-fw"></i></div>')
   jQuery('li#ca-history a').prepend('<div class="drop-icon"><i class="fa fa-history fa-fw"></i></div>')
   jQuery('li#ca-delete a').prepend('<div class="drop-icon"><i class="fa fa-trash-o fa-fw"></i></div>')
@@ -73,4 +70,11 @@ if ( jQuery( '#ca-addsection' ).length ) {
   // Turn categories into labels
   jQuery('#mw-normal-catlinks ul li a').addClass('label');
 
+});
+
+// Have to wait until the window is fully loaded because of Visual Editor to prepend icons for editing
+jQuery(window).load(function() {
+  jQuery('li#ca-ve-edit a').prepend('<div class="drop-icon"><i class="fa fa-pencil fa-fw"></i></div>')
+  jQuery('li#ca-viewsource a').prepend('<div class="drop-icon"><i class="fa fa-book fa-fw"></i></div>')
+  jQuery('li#ca-edit a').prepend('<div class="drop-icon"><i class="fa fa-pencil-square-o fa-fw"></i></div>')
 });

--- a/assets/stylesheets/foreground.css
+++ b/assets/stylesheets/foreground.css
@@ -29,6 +29,34 @@ a#actions-button { float:right; z-index: 499; }
 [dir=ltr] { direction: ltr; }
 [dir=rtl] { direction: rtl; }
 
+/* Style MW Table of Contents */
+.toctoggle,
+.toctoggle a { 
+  line-height: 2em;
+  display: inline;
+  vertical-align:top;
+}
+
+#toctitle h2 {
+  display: inline;
+  font-size: 1.8rem;
+}
+
+#toc, .toc {
+  padding: 1em 1em;
+  border: 1px solid #dddddd;
+  display: inline-block;
+  width: auto;
+  margin: 1.5em 0;
+}
+
+#toc ul, .toc ul {
+  list-style-type: none;
+  list-style-image: none;
+  padding: 0;
+  width: auto;
+}
+
 /* Hide the page actions button for special pages (cuz there's nothing in it) */
 .mw-special-FormEdit a#actions-button, .ns-special a#actions-button { display:none; }
 


### PR DESCRIPTION
* Improved TOC look
* Went ahead and moved Visual Editor icons to the `(window).load` function 